### PR TITLE
Feature/template per row

### DIFF
--- a/parser/SparqlParser.php
+++ b/parser/SparqlParser.php
@@ -51,8 +51,8 @@ class SparqlParser {
 			$templateBare = isset( $vars["templateBare"] ) ? $vars["templateBare"] : '';
 			$footer = isset( $vars["footer"] ) ? $vars["footer"] : '';
 			$preview = isset( $vars["preview"] ) ? $vars["preview"] : '';
-			$introtemplate = isset( $vars["intro"] ) ? $vars["intro"] : '';
-			$outrotemplate = isset( $vars["outro"] ) ? $vars["outro"] : '';
+			$introtemplate = isset( $vars["introtemplate"] ) ? $vars["introtemplate"] : '';
+			$outrotemplate = isset( $vars["outrotemplate"] ) ? $vars["outrotemplate"] : '';
 
 			$chart = isset( $vars["chart"] ) ? $vars["chart"] : '';
 			$options = isset( $vars["options"] ) ? $vars["options"] : '';

--- a/parser/SparqlParser.php
+++ b/parser/SparqlParser.php
@@ -55,6 +55,7 @@ class SparqlParser {
 			$outro = isset( $vars["outro"] ) ? $vars["outro"] : '';
 			$introtemplate = isset( $vars["introtemplate"] ) ? $vars["introtemplate"] : '';
 			$outrotemplate = isset( $vars["outrotemplate"] ) ? $vars["outrotemplate"] : '';
+			$userparam = isset( $vars["userparam"] ) ? $vars["userparam"] : '';
 
 			$chart = isset( $vars["chart"] ) ? $vars["chart"] : '';
 			$options = isset( $vars["options"] ) ? $vars["options"] : '';
@@ -127,7 +128,8 @@ class SparqlParser {
 							$preview,
 							$debug,
 							$log,
-							$noResultMsg
+							$noResultMsg,
+							$userparam
 						);
 					}
 					if ( $templates != "" ) {
@@ -144,7 +146,9 @@ class SparqlParser {
 							$preview,
 							$debug,
 							$log,
-							$noResultMsg );
+							$noResultMsg,
+							$userparam
+						);
 					} else {
 						return self::simpleHTML(
 							$parser,
@@ -272,7 +276,8 @@ class SparqlParser {
 		$preview = '',
 		$debug = null,
 		$log = '',
-		$noResultMsg = '' ) {
+		$noResultMsg = '',
+		$userparam = '' ) {
 		$isDebug = self::isDebug( $debug );
 		$specialC = [ "&#39;" ];
 		$replaceC = [ "'" ];
@@ -313,7 +318,7 @@ class SparqlParser {
 				$str = $intro;
 			}
 			else if ($introtemplate != '') {
-				$str = '{{' . $introtemplate . '}}';
+				$str = '{{' . $introtemplate . ($userparam != '' ? '|userparam=' . $userparam : '') . '}}';
 			}
 			$arrayParameters = [];
 			$nbRows = 0;
@@ -337,6 +342,9 @@ class SparqlParser {
 						}
 					}
 				}
+				if ($userparam != '') {
+					$arrayParameters['userparam'] = $userparam;
+				}
 				$str .= "{{" . $template
 					. "|" . implode("|", $arrayParameters)
 					. "}}";
@@ -346,7 +354,7 @@ class SparqlParser {
 				$str .= $outro;
 			}
 			else if ($outrotemplate != '') {
-				$str .= '{{' . $outrotemplate . '}}';
+				$str .= '{{' . $outrotemplate . ($userparam != '' ? '|userparam=' . $userparam : '') . '}}';
 			}
 
 			if ($footer != "NO" && $footer != "no") {
@@ -395,7 +403,8 @@ class SparqlParser {
 		$preview = '',
 		$debug = null,
 		$log = '',
-		$noResultMsg = '' ) {
+		$noResultMsg = '',
+		$userparam = '' ) {
 		$isDebug = self::isDebug( $debug );
 		$specialC = [ "&#39;" ];
 		$replaceC = [ "'" ];
@@ -480,6 +489,9 @@ class SparqlParser {
 							$arrayParameters[] = $variable . " = " . $row[$variable];
 						}
 					}
+				}
+				if ($userparam != '') {
+					$arrayParameters['userparam'] = $userparam;
 				}
 				foreach ( $TableFormatTemplates as $key => $TableFormatTemplate ) {
 					if ( empty( $TableFormatTemplate ) ) {

--- a/parser/SparqlParser.php
+++ b/parser/SparqlParser.php
@@ -51,6 +51,8 @@ class SparqlParser {
 			$templateBare = isset( $vars["templateBare"] ) ? $vars["templateBare"] : '';
 			$footer = isset( $vars["footer"] ) ? $vars["footer"] : '';
 			$preview = isset( $vars["preview"] ) ? $vars["preview"] : '';
+			$intro = isset( $vars["intro"] ) ? $vars["intro"] : '';
+			$outro = isset( $vars["outro"] ) ? $vars["outro"] : '';
 			$introtemplate = isset( $vars["introtemplate"] ) ? $vars["introtemplate"] : '';
 			$outrotemplate = isset( $vars["outrotemplate"] ) ? $vars["outrotemplate"] : '';
 
@@ -117,6 +119,8 @@ class SparqlParser {
 							$config,
 							$endpoint,
 							$template,
+							$intro,
+							$outro,
 							$introtemplate,
 							$outrotemplate,
 							$footer,
@@ -260,6 +264,8 @@ class SparqlParser {
 		$config,
 		$endpoint,
 		$template,
+		$intro,
+		$outro,
 		$introtemplate,
 		$outrotemplate,
 		$footer = '',
@@ -303,7 +309,10 @@ class SparqlParser {
 		if ( empty( $rs['result']['rows'] ) && !empty( $noResultMsg ) ) {
 			$str = $noResultMsg;
 		} else {
-			if ($introtemplate != '') {
+			if ($intro != '') {
+				$str = $intro;
+			}
+			else if ($introtemplate != '') {
 				$str = '{{' . $introtemplate . '}}';
 			}
 			$arrayParameters = [];
@@ -333,7 +342,10 @@ class SparqlParser {
 					. "}}";
 				$nbRows++;
 			}
-			if ($outrotemplate != '') {
+			if ($outro != '') {
+				$str .= $outro;
+			}
+			else if ($outrotemplate != '') {
 				$str .= '{{' . $outrotemplate . '}}';
 			}
 

--- a/parser/SparqlParser.php
+++ b/parser/SparqlParser.php
@@ -343,7 +343,7 @@ class SparqlParser {
 					}
 				}
 				if ($userparam != '') {
-					$arrayParameters['userparam'] = $userparam;
+					$arrayParameters[] = 'userparam=' . $userparam;
 				}
 				$str .= "{{" . $template
 					. "|" . implode("|", $arrayParameters)
@@ -491,7 +491,7 @@ class SparqlParser {
 					}
 				}
 				if ($userparam != '') {
-					$arrayParameters['userparam'] = $userparam;
+					$arrayParameters[] = 'userparam=' . $userparam;
 				}
 				foreach ( $TableFormatTemplates as $key => $TableFormatTemplate ) {
 					if ( empty( $TableFormatTemplate ) ) {


### PR DESCRIPTION
I am creating this pull request as a way to easily describe my patch, knowing that the main repo is not on github.

This PR includes three parts:
1. SparqlParser::simpleHTMLWithTemplate does not use MediaWiki table syntax anymore but proper HTML tags. This fixes formatting issues I encountered when result variables contain newlines.
2. A new way of formatting the results, similar to what SMW provides: a template which formats an entire result row in combination with intro and outro templates.
3. A new parameter "userparam" (also inspired by SMW) which simply allows to inject a fixed value into the result rows.